### PR TITLE
get BepInEx config path programmatically

### DIFF
--- a/Helpers/ConfigDefaultHelper.cs
+++ b/Helpers/ConfigDefaultHelper.cs
@@ -7,7 +7,7 @@ namespace Notify.Helpers
 {
     internal class ConfigDefaultHelper
     {
-        public static readonly string ConfigPath = Path.Combine(BepInEx.Paths.BepInExConfigPath, "Notify");
+        public static readonly string ConfigPath = Path.Combine(BepInEx.Paths.ConfigPath, "Notify");
 
         public static Dictionary<string, string> DefaultAnnounceDictionary => new Dictionary<string, string>()
         {

--- a/Helpers/ConfigDefaultHelper.cs
+++ b/Helpers/ConfigDefaultHelper.cs
@@ -7,6 +7,7 @@ namespace Notify.Helpers
 {
     internal class ConfigDefaultHelper
     {
+        public static readonly string ConfigPath = Path.Combine(BepInEx.Paths.BepInExConfigPath, "Notify");
 
         public static Dictionary<string, string> DefaultAnnounceDictionary => new Dictionary<string, string>()
         {
@@ -71,26 +72,25 @@ namespace Notify.Helpers
         public static void CreateDefaultNotificationTextConfig()
         {
             var jsonOutPut = System.Text.Json.JsonSerializer.Serialize(DefaultAnnounceDictionary);
-            File.WriteAllText("BepInEx/config/Notify/default_announce.json", jsonOutPut);
+            File.WriteAllText(Path.Combine(ConfigPath, "default_announce.json"), jsonOutPut);
         }
 
         public static void CreateOnlineDefaultConfig()
         {
             var jsonOutPut = System.Text.Json.JsonSerializer.Serialize(DefaultOnline);
-            File.WriteAllText("BepInEx/config/Notify/users_online.json", jsonOutPut);
+            File.WriteAllText(Path.Combine(ConfigPath, "users_online.json"), jsonOutPut);
         }
 
         public static void CreateOfflineDefaultConfig()
         {
             var jsonOutPut = System.Text.Json.JsonSerializer.Serialize(DefaultOffline);
-            File.WriteAllText("BepInEx/config/Notify/users_offline.json", jsonOutPut);
+            File.WriteAllText(Path.Combine(ConfigPath, "users_offline.json"), jsonOutPut);
         }
 
         public static void CreateLocationVBloodDefaultConfig()
         {
             var jsonOutPut = System.Text.Json.JsonSerializer.Serialize(PrefabToNamesDefault);
-            File.WriteAllText("BepInEx/config/Notify/prefabs_names.json", jsonOutPut);
+            File.WriteAllText(Path.Combine(ConfigPath, "prefabs_names.json"), jsonOutPut);
         }
-
     }
 }

--- a/Helpers/LoadConfigHelper.cs
+++ b/Helpers/LoadConfigHelper.cs
@@ -17,7 +17,7 @@ namespace Notify.Helpers
         }
         public static void LoadDefaultAnnounce()
         {
-            var json = File.ReadAllText("BepInEx/config/Notify/default_announce.json");
+            var json = File.ReadAllText(Path.Combine(ConfigDefaultHelper.ConfigPath, "default_announce.json"));
             var dictionary = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
             DBHelper.setDefaultAnnounce(dictionary);
             Plugin.Logger.LogInfo("DefaultAnnounce Load OK.");
@@ -25,7 +25,7 @@ namespace Notify.Helpers
 
         public static void LoadUsersConfigOnline()
         {
-            var json = File.ReadAllText("BepInEx/config/Notify/users_online.json");
+            var json = File.ReadAllText(Path.Combine(ConfigDefaultHelper.ConfigPath, "users_online.json"));
             Plugin.Logger.LogInfo($"cargado fichero {json}");
             var dictionary = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
             Plugin.Logger.LogInfo($"convertido fichero en diccionario");
@@ -35,7 +35,7 @@ namespace Notify.Helpers
 
         public static void LoadUsersConfigOffline()
         {
-            var json = File.ReadAllText("BepInEx/config/Notify/users_offline.json");
+            var json = File.ReadAllText(Path.Combine(ConfigDefaultHelper.ConfigPath, "users_offline.json"));
             var dictionary = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
             DBHelper.setUsersOffline(dictionary);
             Plugin.Logger.LogInfo("UsersConfigOffline Load OK.");
@@ -43,7 +43,7 @@ namespace Notify.Helpers
 
         public static void LoadPrefabsName()
         {
-            var json = File.ReadAllText("BepInEx/config/Notify/prefabs_names.json");
+            var json = File.ReadAllText(Path.Combine(ConfigDefaultHelper.ConfigPath, "prefabs_names.json"));
             var dictionary = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
             DBHelper.setPrefabsNames(dictionary);
             Plugin.Logger.LogInfo("PrefabToNames Load OK.");


### PR DESCRIPTION
bepinex exposes the config path so we should use this otherwise the root directory of the game is used as the working directory but the bepinex config might not be in there in some cases (e.g. if the mod manager is used)