### PR TITLE
Simplify config command with VCF

### DIFF
--- a/Helpers/DBHelper.cs
+++ b/Helpers/DBHelper.cs
@@ -5,278 +5,233 @@ using Notify.AutoAnnouncer.Models;
 
 namespace Notify.Helpers
 {
-    internal class DBHelper
-    {
-        private static bool AnnounceOnline = false;
-        private static bool AnnounceeOffline = false;
-        private static bool AnnounceNewUser = false;
-        private static bool AnnounceVBlood = false;
-        private static string VBloodFinalConcatCharacters = "and";
-        private static bool AutoAnnouncer = false;
-        private static bool MessageOfTheDayEnabled = false;
-        private static int IntervalAutoAnnouncer = 0;
-        private static List<AutoAnnouncerMessage> AutoAnnouncerMessages = new List<AutoAnnouncerMessage>();
+	internal class DBHelper
+	{
+		private static string VBloodFinalConcatCharacters = "and";
+		private static int IntervalAutoAnnouncer = 0;
+		private static List<AutoAnnouncerMessage> AutoAnnouncerMessages = new List<AutoAnnouncerMessage>();
 
-        private static List<string> MessageOfTheDay = new List<string>();
+		private static List<string> MessageOfTheDay = new List<string>();
 
-        private static Dictionary<string, string> DefaultAnnounce { get; set; } = new Dictionary<string, string>();
+		private static Dictionary<string, string> DefaultAnnounce { get; set; } = new Dictionary<string, string>();
 
-        private static Dictionary<string, string> UsersConfigOnline { get; set; } = new Dictionary<string, string>();
+		private static Dictionary<string, string> UsersConfigOnline { get; set; } = new Dictionary<string, string>();
 
-        private static Dictionary<string, string> UsersConfigOffline { get; set; } = new Dictionary<string, string>();
+		private static Dictionary<string, string> UsersConfigOffline { get; set; } = new Dictionary<string, string>();
 
-        private static Dictionary<string, string> PrefabToNames { get; set; } = new Dictionary<string, string>();
+		private static Dictionary<string, string> PrefabToNames { get; set; } = new Dictionary<string, string>();
 
-        private static Dictionary<string, bool> VBloodNotifyIgnore { get; set; } = new Dictionary<string, bool>();
+		private static Dictionary<string, bool> VBloodNotifyIgnore { get; set; } = new Dictionary<string, bool>();
+	
+		static DBHelper()
+		{
+			setAllFeatures(false);
+		}
 
-        public static void setAnnounceOnline(bool value)
-        {
-            AnnounceOnline = value;
-        }
+		internal static Dictionary<NotifyFeature, bool> EnabledFeatures = new();
 
-        public static void setAnnounceOffline(bool value)
-        {
-            AnnounceeOffline = value;
-        }
+		internal static void setAllFeatures(bool isEnabled)
+		{
+			foreach (NotifyFeature feature in System.Enum.GetValues(typeof(NotifyFeature)))
+			{
+				EnabledFeatures[feature] = isEnabled;
+			}
+		}
 
-        public static void setAnnounceNewUser(bool value)
-        {
-            AnnounceNewUser = value;
-        }
+		public static void setVBloodFinalConcatCharacters(string value)
+		{
+			VBloodFinalConcatCharacters = value;
+		}
+		
+		public static string getVBloodFinalConcatCharacters()
+		{
+			return VBloodFinalConcatCharacters;
+		}
 
-        public static void setAnnounceVBlood(bool value)
-        {
-            AnnounceVBlood = value;
-        }
+		public static bool setDefaultAnnounce(Dictionary<string, string> value)
+		{
+			if (value == null)
+				return false;
 
-        public static void setVBloodFinalConcatCharacters(string value)
-        {
-            VBloodFinalConcatCharacters = value;
-        }
+			DefaultAnnounce = value;
+			return true;
+		}
+		public static bool setUsersOnline(Dictionary<string, string> value)
+		{
+			if (value == null)
+				return false;
 
-        public static bool isEnabledAnnounceOnline()
-        {
-            return AnnounceOnline;
-        }
-        public static bool isEnabledAnnounceeOffline()
-        {
-            return AnnounceeOffline;
-        }
+			UsersConfigOnline = value;
+			return true;
+		}
+		public static bool setUsersOffline(Dictionary<string, string> value)
+		{
+			if (value == null)
+				return false;
 
-        public static bool isEnabledAnnounceNewUser()
-        {
-            return AnnounceNewUser;
-        }
+			UsersConfigOffline = value;
+			return true;
+		}
+		public static bool setPrefabsNames(Dictionary<string, string> value)
+		{
+			if (value == null)
+				return false;
 
-        public static bool isEnabledAnnounceVBlood()
-        {
-            return AnnounceVBlood;
-        }
+			PrefabToNames = value;
+			return true;
+		}
+		public static bool setVBloodNotifyIgnore(Dictionary<string, bool> value)
+		{
+			if (value == null)
+				return false;
 
-        public static string getVBloodFinalConcatCharacters()
-        {
-            return VBloodFinalConcatCharacters;
-        }
+			VBloodNotifyIgnore = value;
+			return true;
+		}
 
-        public static bool setDefaultAnnounce(Dictionary<string, string> value)
-        {
-            if (value == null)
-                return false;
+		public static string getDefaultAnnounceValue(string value)
+		{
+			if (value == null)
+				return value;
 
-            DefaultAnnounce = value;
-            return true;
-        }
-        public static bool setUsersOnline(Dictionary<string, string> value)
-        {
-            if (value == null)
-                return false;
+			if (DefaultAnnounce.ContainsKey(value))
+			{
+				return DefaultAnnounce[value];
+			}
+			else
+			{
+				return value;
+			}
+		}
 
-            UsersConfigOnline = value;
-            return true;
-        }
-        public static bool setUsersOffline(Dictionary<string, string> value)
-        {
-            if (value == null)
-                return false;
+		public static string getUserOnlineValue(string user)
+		{
+			if (user == null || user == "")
+			{
+				return getDefaultAnnounceValue("newUser");
+			}
 
-            UsersConfigOffline = value;
-            return true;
-        }
-        public static bool setPrefabsNames(Dictionary<string, string> value)
-        {
-            if (value == null)
-                return false;
+			if (UsersConfigOnline.ContainsKey(user))
+			{
+				return UsersConfigOnline[user];
+			}
+			else
+			{
+				return getDefaultAnnounceValue("online");
+			}
+		}
 
-            PrefabToNames = value;
-            return true;
-        }
-        public static bool setVBloodNotifyIgnore(Dictionary<string, bool> value)
-        {
-            if (value == null)
-                return false;
+		public static string getUserOfflineValue(string user)
+		{
+			if (user == null || user == "")
+			{
+				return user;
+			}
 
-            VBloodNotifyIgnore = value;
-            return true;
-        }
+			if (UsersConfigOffline.ContainsKey(user))
+			{
+				return UsersConfigOffline[user];
+			}
+			else
+			{
+				return getDefaultAnnounceValue("offline");
+			}
+		}
 
-        public static string getDefaultAnnounceValue(string value)
-        {
-            if (value == null)
-                return value;
+		public static string getPrefabNameValue(string prefabName)
+		{
+			if (prefabName == null)
+			{
+				return "NoPrefabName";
+			}
 
-            if (DefaultAnnounce.ContainsKey(value))
-            {
-                return DefaultAnnounce[value];
-            } else
-            {
-                return value;
-            }
-        }
+			if (PrefabToNames.ContainsKey(prefabName))
+			{
+				return PrefabToNames[prefabName];
+			}
+			else
+			{
+				return PrefabToNames["NoPrefabName"];
+			}
+		}
 
-        public static string getUserOnlineValue(string user)
-        {
-            if (user == null || user == "")
-            {
-                return getDefaultAnnounceValue("newUser");
-            }
+		public static bool getVBloodNotifyIgnore(string characterName)
+		{
+			if (characterName == null)
+			{
+				return false;
+			}
 
-            if (UsersConfigOnline.ContainsKey(user))
-            {
-                return UsersConfigOnline[user];
-            } else
-            {
-                return getDefaultAnnounceValue("online");
-            }
-        }
+			if (VBloodNotifyIgnore.ContainsKey(characterName))
+			{
+				return true;
+			}
+			else
+			{
+				return false;
+			}
+		}
 
-        public static string getUserOfflineValue(string user)
-        {
-            if (user == null || user == "")
-            {
-                return user;
-            }
+		public static bool addVBloodNotifyIgnore(string characterName)
+		{
 
-            if (UsersConfigOffline.ContainsKey(user))
-            {
-                return UsersConfigOffline[user];
-            } else
-            {
-                return getDefaultAnnounceValue("offline");
-            }
-        }
+			if (VBloodNotifyIgnore.ContainsKey(characterName))
+			{
+				return true;
+			}
+			else
+			{
+				VBloodNotifyIgnore.Add(characterName, true);
+				SaveConfigHelper.SaveVBloodNotifyIgnoreConfig(VBloodNotifyIgnore);
+				return true;
+			}
+		}
 
-        public static string getPrefabNameValue(string prefabName)
-        {
-            if (prefabName == null)
-            {
-                return "NoPrefabName";
-            }
+		public static bool removeVBloodNotifyIgnore(string characterName)
+		{
 
-            if (PrefabToNames.ContainsKey(prefabName))
-            {
-                return PrefabToNames[prefabName];
-            } else
-            {
-                return PrefabToNames["NoPrefabName"];
-            }
-        }
+			if (VBloodNotifyIgnore.ContainsKey(characterName))
+			{
+				VBloodNotifyIgnore.Remove(characterName);
+				SaveConfigHelper.SaveVBloodNotifyIgnoreConfig(VBloodNotifyIgnore);
+				return true;
+			}
+			else
+			{
+				return true;
+			}
+		}
 
-        public static bool getVBloodNotifyIgnore(string characterName)
-        {
-            if (characterName == null)
-            {
-                return false;
-            }
+		public static int getIntervalAutoAnnouncer()
+		{
+			return IntervalAutoAnnouncer;
+		}
 
-            if (VBloodNotifyIgnore.ContainsKey(characterName))
-            {
-                return true;
-            } else
-            {
-                return false;
-            }
-        }
+		public static void setIntervalAutoAnnouncer(int intervalAutoAnnouncer)
+		{
+			IntervalAutoAnnouncer = intervalAutoAnnouncer;
+		}
 
-        public static bool addVBloodNotifyIgnore(string characterName)
-        {
-            
-            if (VBloodNotifyIgnore.ContainsKey(characterName))
-            {
-                return true;
-            } else
-            {
-                VBloodNotifyIgnore.Add(characterName, true);
-                SaveConfigHelper.SaveVBloodNotifyIgnoreConfig(VBloodNotifyIgnore);
-                return true;
-            }
-        }
+		public static List<AutoAnnouncerMessage> getAutoAnnouncerMessages()
+		{
+			return AutoAnnouncerMessages;
+		}
 
-        public static bool removeVBloodNotifyIgnore(string characterName)
-        {
+		public static void addAutoAnnouncerMessages(AutoAnnouncerMessage autoAnnouncerMessages)
+		{
+			AutoAnnouncerMessages.Add(autoAnnouncerMessages);
+		}
 
-            if (VBloodNotifyIgnore.ContainsKey(characterName))
-            {
-                VBloodNotifyIgnore.Remove(characterName);
-                SaveConfigHelper.SaveVBloodNotifyIgnoreConfig(VBloodNotifyIgnore);
-                return true;
-            }
-            else
-            {
-                return true;
-            }
-        }
+		public static void setMessageOfTheDay(List<string> _messageOfTheDay)
+		{
+			MessageOfTheDay = _messageOfTheDay;
+		}
 
-        public static bool isEnabledAutoAnnouncer()
-        {
-            return AutoAnnouncer;
-        }
-
-        public static void setAutoAnnouncer(bool autoAnnouncer)
-        {
-            AutoAnnouncer = autoAnnouncer;
-        }
-
-        public static int getIntervalAutoAnnouncer()
-        {
-            return IntervalAutoAnnouncer;
-        }
-
-        public static void setIntervalAutoAnnouncer(int intervalAutoAnnouncer)
-        {
-            IntervalAutoAnnouncer = intervalAutoAnnouncer;
-        }
-
-        public static List<AutoAnnouncerMessage> getAutoAnnouncerMessages()
-        {
-            return AutoAnnouncerMessages;
-        }
-
-        public static void addAutoAnnouncerMessages(AutoAnnouncerMessage autoAnnouncerMessages)
-        {
-            AutoAnnouncerMessages.Add(autoAnnouncerMessages);
-        }
+		public static List<string> getMessageOfTheDay()
+		{
+			return MessageOfTheDay;
+		}
 
 
-        public static void setMessageOfTheDayEnabled(bool _messageOfTheDay)
-        {
-            MessageOfTheDayEnabled = _messageOfTheDay;
-        }
-
-        public static bool isEnabledMessageOfTheDay()
-        {
-            return MessageOfTheDayEnabled;
-        }
-
-        public static void setMessageOfTheDay(List<string> _messageOfTheDay)
-        {
-            MessageOfTheDay = _messageOfTheDay;
-        }
-
-        public static List<string> getMessageOfTheDay()
-        {
-            return MessageOfTheDay;
-        }
-
-
-    }
+	}
 }

--- a/Helpers/DBHelper.cs
+++ b/Helpers/DBHelper.cs
@@ -5,233 +5,233 @@ using Notify.AutoAnnouncer.Models;
 
 namespace Notify.Helpers
 {
-	internal class DBHelper
-	{
-		private static string VBloodFinalConcatCharacters = "and";
-		private static int IntervalAutoAnnouncer = 0;
-		private static List<AutoAnnouncerMessage> AutoAnnouncerMessages = new List<AutoAnnouncerMessage>();
+    internal class DBHelper
+    {
+        private static string VBloodFinalConcatCharacters = "and";
+        private static int IntervalAutoAnnouncer = 0;
+        private static List<AutoAnnouncerMessage> AutoAnnouncerMessages = new List<AutoAnnouncerMessage>();
 
-		private static List<string> MessageOfTheDay = new List<string>();
+        private static List<string> MessageOfTheDay = new List<string>();
 
-		private static Dictionary<string, string> DefaultAnnounce { get; set; } = new Dictionary<string, string>();
+        private static Dictionary<string, string> DefaultAnnounce { get; set; } = new Dictionary<string, string>();
 
-		private static Dictionary<string, string> UsersConfigOnline { get; set; } = new Dictionary<string, string>();
+        private static Dictionary<string, string> UsersConfigOnline { get; set; } = new Dictionary<string, string>();
 
-		private static Dictionary<string, string> UsersConfigOffline { get; set; } = new Dictionary<string, string>();
+        private static Dictionary<string, string> UsersConfigOffline { get; set; } = new Dictionary<string, string>();
 
-		private static Dictionary<string, string> PrefabToNames { get; set; } = new Dictionary<string, string>();
+        private static Dictionary<string, string> PrefabToNames { get; set; } = new Dictionary<string, string>();
 
-		private static Dictionary<string, bool> VBloodNotifyIgnore { get; set; } = new Dictionary<string, bool>();
-	
-		static DBHelper()
-		{
-			setAllFeatures(false);
-		}
+        private static Dictionary<string, bool> VBloodNotifyIgnore { get; set; } = new Dictionary<string, bool>();
 
-		internal static Dictionary<NotifyFeature, bool> EnabledFeatures = new();
+        static DBHelper()
+        {
+            setAllFeatures(false);
+        }
 
-		internal static void setAllFeatures(bool isEnabled)
-		{
-			foreach (NotifyFeature feature in System.Enum.GetValues(typeof(NotifyFeature)))
-			{
-				EnabledFeatures[feature] = isEnabled;
-			}
-		}
+        internal static Dictionary<NotifyFeature, bool> EnabledFeatures = new();
 
-		public static void setVBloodFinalConcatCharacters(string value)
-		{
-			VBloodFinalConcatCharacters = value;
-		}
-		
-		public static string getVBloodFinalConcatCharacters()
-		{
-			return VBloodFinalConcatCharacters;
-		}
+        internal static void setAllFeatures(bool isEnabled)
+        {
+            foreach (NotifyFeature feature in System.Enum.GetValues(typeof(NotifyFeature)))
+            {
+                EnabledFeatures[feature] = isEnabled;
+            }
+        }
 
-		public static bool setDefaultAnnounce(Dictionary<string, string> value)
-		{
-			if (value == null)
-				return false;
+        public static void setVBloodFinalConcatCharacters(string value)
+        {
+            VBloodFinalConcatCharacters = value;
+        }
 
-			DefaultAnnounce = value;
-			return true;
-		}
-		public static bool setUsersOnline(Dictionary<string, string> value)
-		{
-			if (value == null)
-				return false;
+        public static string getVBloodFinalConcatCharacters()
+        {
+            return VBloodFinalConcatCharacters;
+        }
 
-			UsersConfigOnline = value;
-			return true;
-		}
-		public static bool setUsersOffline(Dictionary<string, string> value)
-		{
-			if (value == null)
-				return false;
+        public static bool setDefaultAnnounce(Dictionary<string, string> value)
+        {
+            if (value == null)
+                return false;
 
-			UsersConfigOffline = value;
-			return true;
-		}
-		public static bool setPrefabsNames(Dictionary<string, string> value)
-		{
-			if (value == null)
-				return false;
+            DefaultAnnounce = value;
+            return true;
+        }
+        public static bool setUsersOnline(Dictionary<string, string> value)
+        {
+            if (value == null)
+                return false;
 
-			PrefabToNames = value;
-			return true;
-		}
-		public static bool setVBloodNotifyIgnore(Dictionary<string, bool> value)
-		{
-			if (value == null)
-				return false;
+            UsersConfigOnline = value;
+            return true;
+        }
+        public static bool setUsersOffline(Dictionary<string, string> value)
+        {
+            if (value == null)
+                return false;
 
-			VBloodNotifyIgnore = value;
-			return true;
-		}
+            UsersConfigOffline = value;
+            return true;
+        }
+        public static bool setPrefabsNames(Dictionary<string, string> value)
+        {
+            if (value == null)
+                return false;
 
-		public static string getDefaultAnnounceValue(string value)
-		{
-			if (value == null)
-				return value;
+            PrefabToNames = value;
+            return true;
+        }
+        public static bool setVBloodNotifyIgnore(Dictionary<string, bool> value)
+        {
+            if (value == null)
+                return false;
 
-			if (DefaultAnnounce.ContainsKey(value))
-			{
-				return DefaultAnnounce[value];
-			}
-			else
-			{
-				return value;
-			}
-		}
+            VBloodNotifyIgnore = value;
+            return true;
+        }
 
-		public static string getUserOnlineValue(string user)
-		{
-			if (user == null || user == "")
-			{
-				return getDefaultAnnounceValue("newUser");
-			}
+        public static string getDefaultAnnounceValue(string value)
+        {
+            if (value == null)
+                return value;
 
-			if (UsersConfigOnline.ContainsKey(user))
-			{
-				return UsersConfigOnline[user];
-			}
-			else
-			{
-				return getDefaultAnnounceValue("online");
-			}
-		}
+            if (DefaultAnnounce.ContainsKey(value))
+            {
+                return DefaultAnnounce[value];
+            }
+            else
+            {
+                return value;
+            }
+        }
 
-		public static string getUserOfflineValue(string user)
-		{
-			if (user == null || user == "")
-			{
-				return user;
-			}
+        public static string getUserOnlineValue(string user)
+        {
+            if (user == null || user == "")
+            {
+                return getDefaultAnnounceValue("newUser");
+            }
 
-			if (UsersConfigOffline.ContainsKey(user))
-			{
-				return UsersConfigOffline[user];
-			}
-			else
-			{
-				return getDefaultAnnounceValue("offline");
-			}
-		}
+            if (UsersConfigOnline.ContainsKey(user))
+            {
+                return UsersConfigOnline[user];
+            }
+            else
+            {
+                return getDefaultAnnounceValue("online");
+            }
+        }
 
-		public static string getPrefabNameValue(string prefabName)
-		{
-			if (prefabName == null)
-			{
-				return "NoPrefabName";
-			}
+        public static string getUserOfflineValue(string user)
+        {
+            if (user == null || user == "")
+            {
+                return user;
+            }
 
-			if (PrefabToNames.ContainsKey(prefabName))
-			{
-				return PrefabToNames[prefabName];
-			}
-			else
-			{
-				return PrefabToNames["NoPrefabName"];
-			}
-		}
+            if (UsersConfigOffline.ContainsKey(user))
+            {
+                return UsersConfigOffline[user];
+            }
+            else
+            {
+                return getDefaultAnnounceValue("offline");
+            }
+        }
 
-		public static bool getVBloodNotifyIgnore(string characterName)
-		{
-			if (characterName == null)
-			{
-				return false;
-			}
+        public static string getPrefabNameValue(string prefabName)
+        {
+            if (prefabName == null)
+            {
+                return "NoPrefabName";
+            }
 
-			if (VBloodNotifyIgnore.ContainsKey(characterName))
-			{
-				return true;
-			}
-			else
-			{
-				return false;
-			}
-		}
+            if (PrefabToNames.ContainsKey(prefabName))
+            {
+                return PrefabToNames[prefabName];
+            }
+            else
+            {
+                return PrefabToNames["NoPrefabName"];
+            }
+        }
 
-		public static bool addVBloodNotifyIgnore(string characterName)
-		{
+        public static bool getVBloodNotifyIgnore(string characterName)
+        {
+            if (characterName == null)
+            {
+                return false;
+            }
 
-			if (VBloodNotifyIgnore.ContainsKey(characterName))
-			{
-				return true;
-			}
-			else
-			{
-				VBloodNotifyIgnore.Add(characterName, true);
-				SaveConfigHelper.SaveVBloodNotifyIgnoreConfig(VBloodNotifyIgnore);
-				return true;
-			}
-		}
+            if (VBloodNotifyIgnore.ContainsKey(characterName))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
 
-		public static bool removeVBloodNotifyIgnore(string characterName)
-		{
+        public static bool addVBloodNotifyIgnore(string characterName)
+        {
 
-			if (VBloodNotifyIgnore.ContainsKey(characterName))
-			{
-				VBloodNotifyIgnore.Remove(characterName);
-				SaveConfigHelper.SaveVBloodNotifyIgnoreConfig(VBloodNotifyIgnore);
-				return true;
-			}
-			else
-			{
-				return true;
-			}
-		}
+            if (VBloodNotifyIgnore.ContainsKey(characterName))
+            {
+                return true;
+            }
+            else
+            {
+                VBloodNotifyIgnore.Add(characterName, true);
+                SaveConfigHelper.SaveVBloodNotifyIgnoreConfig(VBloodNotifyIgnore);
+                return true;
+            }
+        }
 
-		public static int getIntervalAutoAnnouncer()
-		{
-			return IntervalAutoAnnouncer;
-		}
+        public static bool removeVBloodNotifyIgnore(string characterName)
+        {
 
-		public static void setIntervalAutoAnnouncer(int intervalAutoAnnouncer)
-		{
-			IntervalAutoAnnouncer = intervalAutoAnnouncer;
-		}
+            if (VBloodNotifyIgnore.ContainsKey(characterName))
+            {
+                VBloodNotifyIgnore.Remove(characterName);
+                SaveConfigHelper.SaveVBloodNotifyIgnoreConfig(VBloodNotifyIgnore);
+                return true;
+            }
+            else
+            {
+                return true;
+            }
+        }
 
-		public static List<AutoAnnouncerMessage> getAutoAnnouncerMessages()
-		{
-			return AutoAnnouncerMessages;
-		}
+        public static int getIntervalAutoAnnouncer()
+        {
+            return IntervalAutoAnnouncer;
+        }
 
-		public static void addAutoAnnouncerMessages(AutoAnnouncerMessage autoAnnouncerMessages)
-		{
-			AutoAnnouncerMessages.Add(autoAnnouncerMessages);
-		}
+        public static void setIntervalAutoAnnouncer(int intervalAutoAnnouncer)
+        {
+            IntervalAutoAnnouncer = intervalAutoAnnouncer;
+        }
 
-		public static void setMessageOfTheDay(List<string> _messageOfTheDay)
-		{
-			MessageOfTheDay = _messageOfTheDay;
-		}
+        public static List<AutoAnnouncerMessage> getAutoAnnouncerMessages()
+        {
+            return AutoAnnouncerMessages;
+        }
 
-		public static List<string> getMessageOfTheDay()
-		{
-			return MessageOfTheDay;
-		}
+        public static void addAutoAnnouncerMessages(AutoAnnouncerMessage autoAnnouncerMessages)
+        {
+            AutoAnnouncerMessages.Add(autoAnnouncerMessages);
+        }
+
+        public static void setMessageOfTheDay(List<string> _messageOfTheDay)
+        {
+            MessageOfTheDay = _messageOfTheDay;
+        }
+
+        public static List<string> getMessageOfTheDay()
+        {
+            return MessageOfTheDay;
+        }
 
 
-	}
+    }
 }

--- a/Hooks/CommandHook.cs
+++ b/Hooks/CommandHook.cs
@@ -6,7 +6,7 @@ using Unity.Entities;
 namespace Notify.Hooks
 {
     [CommandGroup("notify")]
-    public partial class CommandHook
+    public class CommandHook
     {
 
         private static EntityManager entityManager = VWorld.Server.EntityManager;

--- a/Hooks/CommandHook.cs
+++ b/Hooks/CommandHook.cs
@@ -5,184 +5,109 @@ using Unity.Entities;
 
 namespace Notify.Hooks
 {
-    [CommandGroup("notify")]
-    public class CommandHook
-    {
+	[CommandGroup("notify")]
+	public partial class CommandHook
+	{
 
-        private static EntityManager entityManager = VWorld.Server.EntityManager;
+		private static EntityManager entityManager = VWorld.Server.EntityManager;
 
-        [Command("reload", "rl", description: "To reload the configuration of the user messages online, offline or death of the VBlood boss", adminOnly: true)]
-        public static void RealoadMod(ChatCommandContext ctx)
-        {
+		[Command("reload", "rl", description: "To reload the configuration of the user messages online, offline or death of the VBlood boss", adminOnly: true)]
+		public static void RealoadMod(ChatCommandContext ctx)
+		{
 
-            if (!DBHelper.isEnabledAnnounceeOffline())
-            {
-                LoadConfigHelper.LoadUsersConfigOffline();
-            }
+			if (!DBHelper.EnabledFeatures[NotifyFeature.offline])
+			{
+				LoadConfigHelper.LoadUsersConfigOffline();
+			}
 
-            if (!DBHelper.isEnabledAnnounceOnline())
-            {
-                LoadConfigHelper.LoadUsersConfigOnline();
-            }
+			if (!DBHelper.EnabledFeatures[NotifyFeature.online])
+			{
+				LoadConfigHelper.LoadUsersConfigOnline();
+			}
 
-            if (!DBHelper.isEnabledAnnounceVBlood())
-            {
-                LoadConfigHelper.LoadPrefabsName();
-            }
+			if (!DBHelper.EnabledFeatures[NotifyFeature.vblood])
+			{
+				LoadConfigHelper.LoadPrefabsName();
+			}
 
-            if (!DBHelper.isEnabledAnnounceNewUser())
-            {
-                LoadConfigHelper.LoadDefaultAnnounce();
-            }
+			if (!DBHelper.EnabledFeatures[NotifyFeature.newuser])
+			{
+				LoadConfigHelper.LoadDefaultAnnounce();
+			}
 
-            if (!DBHelper.isEnabledAutoAnnouncer())
-            {
-                LoadConfigHelper.LoadAutoAnnouncerMessagesConfig();
-            }
+			if (!DBHelper.EnabledFeatures[NotifyFeature.auto])
+			{
+				LoadConfigHelper.LoadAutoAnnouncerMessagesConfig();
+			}
 
-            if (!DBHelper.isEnabledMessageOfTheDay())
-            {
-                LoadConfigHelper.LoadMessageOfTheDayConfig();
-            }
+			if (!DBHelper.EnabledFeatures[NotifyFeature.motd])
+			{
+				LoadConfigHelper.LoadMessageOfTheDayConfig();
+			}
 
-            ctx.Reply("Reloaded configuration of Notify mod.");
+			ctx.Reply("Reloaded configuration of Notify mod.");
 
-        }
+		}
 
-        [Command("vblood", "vba", usage: "ignore/unignore", description: "ignore/unignore vblood announce system.", adminOnly: false)]
-        public static void Vbloodannounce(ChatCommandContext ctx, string action = "unignore")
-        {
+		[Command("vblood", "vba", usage: "ignore/unignore", description: "ignore/unignore vblood announce system.", adminOnly: false)]
+		public static void Vbloodannounce(ChatCommandContext ctx, string action = "unignore")
+		{
 
-            var user = ctx.User;
+			var user = ctx.User;
 
-            switch (action)
-            {
-                case "ignore":
-                    DBHelper.addVBloodNotifyIgnore(user.CharacterName.ToString());
-                    ctx.Reply(FontColorChat.Green($"You will not receive any more notifications about the death of the VBlood. To undo this option use the command {FontColorChat.Yellow(".notify vbloodannounce unignore")}"));
-                    break;
-                case "unignore":
-                    DBHelper.removeVBloodNotifyIgnore(user.CharacterName.ToString());
-                    ctx.Reply(FontColorChat.Green($"You will receive notifications about the death of the VBlood. To undo this option use the command {FontColorChat.Yellow(".notify vbloodannounce ignore")}"));
-                    break;
+			switch (action)
+			{
+				case "ignore":
+					DBHelper.addVBloodNotifyIgnore(user.CharacterName.ToString());
+					ctx.Reply(FontColorChat.Green($"You will not receive any more notifications about the death of the VBlood. To undo this option use the command {FontColorChat.Yellow(".notify vbloodannounce unignore")}"));
+					break;
+				case "unignore":
+					DBHelper.removeVBloodNotifyIgnore(user.CharacterName.ToString());
+					ctx.Reply(FontColorChat.Green($"You will receive notifications about the death of the VBlood. To undo this option use the command {FontColorChat.Yellow(".notify vbloodannounce ignore")}"));
+					break;
 
-            }
-        }
+			}
+		}
 
-        [Command("config", "cfg", usage: "[ auto, motd, newuser, online, offline, vblood ] enabled/disabled", description: "To change mod settings. [ auto, motd, newuser, online, offline, vblood ]", adminOnly: true)]
-        public static void ConfigMod(ChatCommandContext ctx, string feature, string action)
-        {
+		[Command("config", "cfg", usage: "[ auto, motd, newuser, online, offline, vblood ] enabled/disabled", description: "To change mod settings. [ auto, motd, newuser, online, offline, vblood ]", adminOnly: true)]
+		public static void ConfigMod(ChatCommandContext ctx, NotifyFeature feature, bool isEnabled)
+		{
 
-            Plugin.Logger.LogInfo("Config Parameters");
-            Plugin.Logger.LogInfo($"{feature}");
-            Plugin.Logger.LogInfo($"{action}");
+			Plugin.Logger.LogInfo("Config Parameters");
+			Plugin.Logger.LogInfo($"{feature}");
+			Plugin.Logger.LogInfo($"{isEnabled}");
 
-            switch (feature)
-            {
-                case "motd":
-                    switch (action)
-                    {
-                        case "enabled":
-                            DBHelper.setMessageOfTheDayEnabled(true);
-                            ctx.Reply(FontColorChat.Green($"Message of the Day: {FontColorChat.Yellow("enable")}"));
-                            break;
-                        case "disabled":
-                            DBHelper.setMessageOfTheDayEnabled(false);
-                            ctx.Reply(FontColorChat.Green($"Message of the Day: {FontColorChat.Yellow("disabled")}"));
-                            break;
-                        default:
-                            ctx.Reply(FontColorChat.Green($"Command Not found: {FontColorChat.Yellow($".notify {feature} {action}")}"));
-                            break;
-                    }
-                    break;
-                case "newuser":
-                    switch (action)
-                    {
-                        case "enabled":
-                            DBHelper.setAnnounceNewUser(true);
-                            ctx.Reply(FontColorChat.Green($"announcenewuser: {FontColorChat.Yellow("enable")}"));
-                            break;
-                        case "disabled":
-                            DBHelper.setAnnounceNewUser(false);
-                            ctx.Reply(FontColorChat.Green($"announcenewuser: {FontColorChat.Yellow("disabled")}"));
-                            break;
-                        default:
-                            ctx.Reply(FontColorChat.Green($"Command Not found: {FontColorChat.Yellow($".notify {feature} {action}")}"));
-                            break;
-                    }
-                    break;
-                case "offline":
-                    switch (action)
-                    {
-                        case "enabled":
-                            DBHelper.setAnnounceOffline(true);
-                            ctx.Reply(FontColorChat.Green($"announceoffline: {FontColorChat.Yellow("enable")}"));
-                            break;
-                        case "disabled":
-                            DBHelper.setAnnounceOffline(false);
-                            ctx.Reply(FontColorChat.Green($"announceoffline: {FontColorChat.Yellow("disabled")}"));
-                            break;
-                        default:
-                            ctx.Reply(FontColorChat.Green($"Command Not found: {FontColorChat.Yellow("disabled")}"));
-                            break;
-                    }
-                    break;
-                case "online":
-                    switch (action)
-                    {
-                        case "enabled":
-                            DBHelper.setAnnounceOnline(true);
-                            ctx.Reply(FontColorChat.Green($"announceonline: {FontColorChat.Yellow("enable")}"));
-                            break;
-                        case "disabled":
-                            DBHelper.setAnnounceOnline(false);
-                            ctx.Reply(FontColorChat.Green($"announceonline: {FontColorChat.Yellow("disabled")}"));
-                            break;
-                        default:
-                            ctx.Reply(FontColorChat.Green($"Command Not found: {FontColorChat.Yellow($".notify {feature} {action}")}"));
-                            break;
-                    }
-                    break;
-                case "auto":
-                    switch (action)
-                    {
-                        case "start":
-                            DBHelper.setAutoAnnouncer(true);
-                            OnInitialize.StartAutoAnnouncer();
-                            ctx.Reply(FontColorChat.Green($"AutoAnnouncer: {FontColorChat.Yellow("start")}"));
-                            break;
-                        case "stop":
-                            DBHelper.setAutoAnnouncer(false);
-                            OnInitialize.StopAutoAnnouncer();
-                            ctx.Reply(FontColorChat.Green($"AutoAnnouncer: {FontColorChat.Yellow("stop")}"));
-                            break;
-                        default:
-                            ctx.Reply(FontColorChat.Green($"Action Not found: {FontColorChat.Yellow($".notify config {feature} {action}")}"));
-                            break;
-                    }
-                    break;
-                case "vblood":
-                    switch (action)
-                    {
-                        case "enabled":
-                            DBHelper.setAnnounceVBlood(true);
-                            ctx.Reply(FontColorChat.Green($"vbloodannounce: {FontColorChat.Yellow("enable")}"));
-                            break;
-                        case "disabled":
-                            DBHelper.setAnnounceVBlood(false);
-                            ctx.Reply(FontColorChat.Green($"vbloodannounce: {FontColorChat.Yellow("disabled")}"));
-                            break;
-                        default:
-                            ctx.Reply(FontColorChat.Green($"Action Not found: {FontColorChat.Yellow($".notify {feature} {action}")}"));
-                            break;
-                    }
-                    break;
-                default:
-                    ctx.Reply(FontColorChat.Green($"Command Not found: {FontColorChat.Yellow($".notify {feature} {action}")}"));
-                    break;
-            }
-        }
 
-    }
+			DBHelper.EnabledFeatures[feature] = isEnabled;
+
+			if (feature == NotifyFeature.auto)
+			{
+				if (isEnabled)
+				{
+					OnInitialize.StartAutoAnnouncer();
+				}
+				else
+				{
+					OnInitialize.StopAutoAnnouncer();
+				}
+			}
+			
+			var message = feature switch
+			{
+				NotifyFeature.motd => $"Message of The Day:",
+				NotifyFeature.newuser => $"Announce New User:",
+				NotifyFeature.online => $"Announce Online:",
+				NotifyFeature.offline => $"Announce Offline:",
+				NotifyFeature.vblood => $"VBlood Announcer:",
+				NotifyFeature.auto => $"Auto Announcer:",
+				_ => throw new System.NotImplementedException(),
+			};
+
+			var enabled = FontColorChat.Yellow(isEnabled ? "Enabled" : "Disabled");
+
+			ctx.Reply(FontColorChat.Green($"{message} {enabled}"));
+		}
+
+	}
 
 }

--- a/Hooks/CommandHook.cs
+++ b/Hooks/CommandHook.cs
@@ -5,109 +5,109 @@ using Unity.Entities;
 
 namespace Notify.Hooks
 {
-	[CommandGroup("notify")]
-	public partial class CommandHook
-	{
+    [CommandGroup("notify")]
+    public partial class CommandHook
+    {
 
-		private static EntityManager entityManager = VWorld.Server.EntityManager;
+        private static EntityManager entityManager = VWorld.Server.EntityManager;
 
-		[Command("reload", "rl", description: "To reload the configuration of the user messages online, offline or death of the VBlood boss", adminOnly: true)]
-		public static void RealoadMod(ChatCommandContext ctx)
-		{
+        [Command("reload", "rl", description: "To reload the configuration of the user messages online, offline or death of the VBlood boss", adminOnly: true)]
+        public static void RealoadMod(ChatCommandContext ctx)
+        {
 
-			if (!DBHelper.EnabledFeatures[NotifyFeature.offline])
-			{
-				LoadConfigHelper.LoadUsersConfigOffline();
-			}
+            if (!DBHelper.EnabledFeatures[NotifyFeature.offline])
+            {
+                LoadConfigHelper.LoadUsersConfigOffline();
+            }
 
-			if (!DBHelper.EnabledFeatures[NotifyFeature.online])
-			{
-				LoadConfigHelper.LoadUsersConfigOnline();
-			}
+            if (!DBHelper.EnabledFeatures[NotifyFeature.online])
+            {
+                LoadConfigHelper.LoadUsersConfigOnline();
+            }
 
-			if (!DBHelper.EnabledFeatures[NotifyFeature.vblood])
-			{
-				LoadConfigHelper.LoadPrefabsName();
-			}
+            if (!DBHelper.EnabledFeatures[NotifyFeature.vblood])
+            {
+                LoadConfigHelper.LoadPrefabsName();
+            }
 
-			if (!DBHelper.EnabledFeatures[NotifyFeature.newuser])
-			{
-				LoadConfigHelper.LoadDefaultAnnounce();
-			}
+            if (!DBHelper.EnabledFeatures[NotifyFeature.newuser])
+            {
+                LoadConfigHelper.LoadDefaultAnnounce();
+            }
 
-			if (!DBHelper.EnabledFeatures[NotifyFeature.auto])
-			{
-				LoadConfigHelper.LoadAutoAnnouncerMessagesConfig();
-			}
+            if (!DBHelper.EnabledFeatures[NotifyFeature.auto])
+            {
+                LoadConfigHelper.LoadAutoAnnouncerMessagesConfig();
+            }
 
-			if (!DBHelper.EnabledFeatures[NotifyFeature.motd])
-			{
-				LoadConfigHelper.LoadMessageOfTheDayConfig();
-			}
+            if (!DBHelper.EnabledFeatures[NotifyFeature.motd])
+            {
+                LoadConfigHelper.LoadMessageOfTheDayConfig();
+            }
 
-			ctx.Reply("Reloaded configuration of Notify mod.");
+            ctx.Reply("Reloaded configuration of Notify mod.");
 
-		}
+        }
 
-		[Command("vblood", "vba", usage: "ignore/unignore", description: "ignore/unignore vblood announce system.", adminOnly: false)]
-		public static void Vbloodannounce(ChatCommandContext ctx, string action = "unignore")
-		{
+        [Command("vblood", "vba", usage: "ignore/unignore", description: "ignore/unignore vblood announce system.", adminOnly: false)]
+        public static void Vbloodannounce(ChatCommandContext ctx, string action = "unignore")
+        {
 
-			var user = ctx.User;
+            var user = ctx.User;
 
-			switch (action)
-			{
-				case "ignore":
-					DBHelper.addVBloodNotifyIgnore(user.CharacterName.ToString());
-					ctx.Reply(FontColorChat.Green($"You will not receive any more notifications about the death of the VBlood. To undo this option use the command {FontColorChat.Yellow(".notify vbloodannounce unignore")}"));
-					break;
-				case "unignore":
-					DBHelper.removeVBloodNotifyIgnore(user.CharacterName.ToString());
-					ctx.Reply(FontColorChat.Green($"You will receive notifications about the death of the VBlood. To undo this option use the command {FontColorChat.Yellow(".notify vbloodannounce ignore")}"));
-					break;
+            switch (action)
+            {
+                case "ignore":
+                    DBHelper.addVBloodNotifyIgnore(user.CharacterName.ToString());
+                    ctx.Reply(FontColorChat.Green($"You will not receive any more notifications about the death of the VBlood. To undo this option use the command {FontColorChat.Yellow(".notify vbloodannounce unignore")}"));
+                    break;
+                case "unignore":
+                    DBHelper.removeVBloodNotifyIgnore(user.CharacterName.ToString());
+                    ctx.Reply(FontColorChat.Green($"You will receive notifications about the death of the VBlood. To undo this option use the command {FontColorChat.Yellow(".notify vbloodannounce ignore")}"));
+                    break;
 
-			}
-		}
+            }
+        }
 
-		[Command("config", "cfg", usage: "[ auto, motd, newuser, online, offline, vblood ] enabled/disabled", description: "To change mod settings. [ auto, motd, newuser, online, offline, vblood ]", adminOnly: true)]
-		public static void ConfigMod(ChatCommandContext ctx, NotifyFeature feature, bool isEnabled)
-		{
+        [Command("config", "cfg", usage: "[ auto, motd, newuser, online, offline, vblood ] enabled/disabled", description: "To change mod settings. [ auto, motd, newuser, online, offline, vblood ]", adminOnly: true)]
+        public static void ConfigMod(ChatCommandContext ctx, NotifyFeature feature, bool isEnabled)
+        {
 
-			Plugin.Logger.LogInfo("Config Parameters");
-			Plugin.Logger.LogInfo($"{feature}");
-			Plugin.Logger.LogInfo($"{isEnabled}");
+            Plugin.Logger.LogInfo("Config Parameters");
+            Plugin.Logger.LogInfo($"{feature}");
+            Plugin.Logger.LogInfo($"{isEnabled}");
 
 
-			DBHelper.EnabledFeatures[feature] = isEnabled;
+            DBHelper.EnabledFeatures[feature] = isEnabled;
 
-			if (feature == NotifyFeature.auto)
-			{
-				if (isEnabled)
-				{
-					OnInitialize.StartAutoAnnouncer();
-				}
-				else
-				{
-					OnInitialize.StopAutoAnnouncer();
-				}
-			}
-			
-			var message = feature switch
-			{
-				NotifyFeature.motd => $"Message of The Day:",
-				NotifyFeature.newuser => $"Announce New User:",
-				NotifyFeature.online => $"Announce Online:",
-				NotifyFeature.offline => $"Announce Offline:",
-				NotifyFeature.vblood => $"VBlood Announcer:",
-				NotifyFeature.auto => $"Auto Announcer:",
-				_ => throw new System.NotImplementedException(),
-			};
+            if (feature == NotifyFeature.auto)
+            {
+                if (isEnabled)
+                {
+                    OnInitialize.StartAutoAnnouncer();
+                }
+                else
+                {
+                    OnInitialize.StopAutoAnnouncer();
+                }
+            }
 
-			var enabled = FontColorChat.Yellow(isEnabled ? "Enabled" : "Disabled");
+            var message = feature switch
+            {
+                NotifyFeature.motd => $"Message of The Day:",
+                NotifyFeature.newuser => $"Announce New User:",
+                NotifyFeature.online => $"Announce Online:",
+                NotifyFeature.offline => $"Announce Offline:",
+                NotifyFeature.vblood => $"VBlood Announcer:",
+                NotifyFeature.auto => $"Auto Announcer:",
+                _ => throw new System.NotImplementedException(),
+            };
 
-			ctx.Reply(FontColorChat.Green($"{message} {enabled}"));
-		}
+            var enabled = FontColorChat.Yellow(isEnabled ? "Enabled" : "Disabled");
 
-	}
+            ctx.Reply(FontColorChat.Green($"{message} {enabled}"));
+        }
+
+    }
 
 }

--- a/Hooks/NotifyFeature.cs
+++ b/Hooks/NotifyFeature.cs
@@ -9,10 +9,10 @@
 /// </remarks>
 public enum NotifyFeature
 {
-	motd,
-	newuser,
-	offline,
-	online,
-	auto,
-	vblood
+    motd,
+    newuser,
+    offline,
+    online,
+    auto,
+    vblood
 }

--- a/Hooks/NotifyFeature.cs
+++ b/Hooks/NotifyFeature.cs
@@ -1,0 +1,18 @@
+﻿namespace Notify;
+
+/// <summary>
+/// These are the different features available for notification in this mod.
+/// </summary>
+/// <remarks>
+/// These are used for command parsing and internally, if you change them you're changing
+/// the command that gets parsed as well.
+/// </remarks>
+public enum NotifyFeature
+{
+	motd,
+	newuser,
+	offline,
+	online,
+	auto,
+	vblood
+}

--- a/Notify.csproj
+++ b/Notify.csproj
@@ -1,24 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
-		<AssemblyName>Notify</AssemblyName>
-		<Description>Add functionality to the server to have MOTD, Auto Announcer, when a user is online, when a user goes offline or when someone kills a VBlood in v rising.</Description>
-		<Version>2.0</Version>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-		<LangVersion>latest</LangVersion>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <AssemblyName>Notify</AssemblyName>
+    <Description>Add functionality to the server to have MOTD, Auto Announcer, when a user is online, when a user goes offline or when someone kills a VBlood in v rising.</Description>
+    <Version>2.0</Version>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
 
-	<Target Name="CopyDLLs" AfterTargets="Build">
-		<Message Text="DLL to V Rising Server" Importance="High" />
-		<Copy SourceFiles="$(TargetDir)$(ProjectName).dll" DestinationFolder="D:\steamcmd\steamapps\common\VRisingDedicatedServer\BepInEx\plugins" />
-		<Message Text="DLL Copied OK" Importance="High" />
-	</Target>
+  <Target Name="CopyDLLs" AfterTargets="Build">
+    <Message Text="DLL to V Rising Server" Importance="High" />
+    <Copy SourceFiles="$(TargetDir)$(ProjectName).dll" DestinationFolder="D:\steamcmd\steamapps\common\VRisingDedicatedServer\BepInEx\plugins" />
+    <Message Text="DLL Copied OK" Importance="High" />
+  </Target>
 
-	<ItemGroup>
-		<PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be*" IncludeAssets="compile" />
-		<PackageReference Include="BepInEx.Core" Version="6.0.0-be*" IncludeAssets="compile" />
-		<PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
-		<PackageReference Include="VRising.Unhollowed.Client" Version="0.6.1.*" />
-		<PackageReference Include="VRising.VampireCommandFramework" Version="0.5.3" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be*" IncludeAssets="compile" />
+    <PackageReference Include="BepInEx.Core" Version="6.0.0-be*" IncludeAssets="compile" />
+    <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
+    <PackageReference Include="VRising.Unhollowed.Client" Version="0.6.1.*" />
+    <PackageReference Include="VRising.VampireCommandFramework" Version="0.5.3" />
+  </ItemGroup>
 </Project>

--- a/Notify.csproj
+++ b/Notify.csproj
@@ -1,26 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<AssemblyName>Notify</AssemblyName>
+		<Description>Add functionality to the server to have MOTD, Auto Announcer, when a user is online, when a user goes offline or when someone kills a VBlood in v rising.</Description>
+		<Version>2.0</Version>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<LangVersion>latest</LangVersion>
+	</PropertyGroup>
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <AssemblyName>Notify</AssemblyName>
-    <Description>Add functionality to the server to have MOTD, Auto Announcer, when a user is online, when a user goes offline or when someone kills a VBlood in v rising.</Description>
-    <Version>2.0</Version>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>latest</LangVersion>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-  </PropertyGroup>
+	<Target Name="CopyDLLs" AfterTargets="Build">
+		<Message Text="DLL to V Rising Server" Importance="High" />
+		<Copy SourceFiles="$(TargetDir)$(ProjectName).dll" DestinationFolder="D:\steamcmd\steamapps\common\VRisingDedicatedServer\BepInEx\plugins" />
+		<Message Text="DLL Copied OK" Importance="High" />
+	</Target>
 
-  <Target Name="CopyDLLs" AfterTargets="Build">
-    <Message Text="DLL to V Rising Server" Importance="High" />
-    <Copy SourceFiles="$(TargetDir)$(ProjectName).dll" DestinationFolder="D:\steamcmd\steamapps\common\VRisingDedicatedServer\BepInEx\plugins" />
-    <Message Text="DLL Copied OK" Importance="High" />
-  </Target>
-
-  <ItemGroup>
-	<PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be*" IncludeAssets="compile" />
-	<PackageReference Include="BepInEx.Core" Version="6.0.0-be*" IncludeAssets="compile" />
-	<PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
-	<PackageReference Include="VRising.Unhollowed.Client" Version="0.6.1.*" />
-    <PackageReference Include="VRising.VampireCommandFramework" Version="0.5.3" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be*" IncludeAssets="compile" />
+		<PackageReference Include="BepInEx.Core" Version="6.0.0-be*" IncludeAssets="compile" />
+		<PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
+		<PackageReference Include="VRising.Unhollowed.Client" Version="0.6.1.*" />
+		<PackageReference Include="VRising.VampireCommandFramework" Version="0.5.3" />
+	</ItemGroup>
 </Project>

--- a/Patch/KillVBlood_Patch.cs
+++ b/Patch/KillVBlood_Patch.cs
@@ -29,7 +29,7 @@ public class VBloodSystem_Patch
     [HarmonyPrefix]
     public static void OnUpdate_Prefix(VBloodSystem __instance)
     {
-        if (DBHelper.isEnabledAnnounceVBlood())
+        if (DBHelper.EnabledFeatures[NotifyFeature.vblood])
         {
             if (__instance.EventList.Length > 0)
             {

--- a/Patch/NotifyOnlineOffline_Patch.cs
+++ b/Patch/NotifyOnlineOffline_Patch.cs
@@ -27,7 +27,7 @@ public class ServerBootstrapSystem_Patch
 
         if (!isNewPlayer)
         {
-            if (DBHelper.isEnabledAnnounceOnline())
+            if (DBHelper.EnabledFeatures[NotifyFeature.online])
             {
                 var _message = DBHelper.getUserOnlineValue(userNick);
                 _message = _message.Replace("#user#", $"{FontColorChat.Yellow(userNick)}");
@@ -37,14 +37,14 @@ public class ServerBootstrapSystem_Patch
         }
         else
         {
-            if (DBHelper.isEnabledAnnounceNewUser())
+            if (DBHelper.EnabledFeatures[NotifyFeature.newuser])
             {
                 var _message = DBHelper.getUserOnlineValue("");
                 ServerChatUtils.SendSystemMessageToAllClients(entityManager, FontColorChat.Green($"{_message}"));
             }
         }
 
-        if (DBHelper.isEnabledMessageOfTheDay())
+        if (DBHelper.EnabledFeatures[NotifyFeature.motd])
         {
             var _messageLines = DBHelper.getMessageOfTheDay();
             var lineReplace = "";
@@ -61,7 +61,7 @@ public class ServerBootstrapSystem_Patch
     [HarmonyPrefix]
     public static void Prefix(ServerBootstrapSystem __instance, NetConnectionId netConnectionId, ConnectionStatusChangeReason connectionStatusReason, string extraData)
     {
-        if (DBHelper.isEnabledAnnounceeOffline())
+        if (DBHelper.EnabledFeatures[NotifyFeature.offline])
         {
             if (connectionStatusReason != ConnectionStatusChangeReason.IncorrectPassword)
             {

--- a/Patch/OnInitialize.cs
+++ b/Patch/OnInitialize.cs
@@ -19,13 +19,17 @@ public class OnInitialize
         Plugin.Logger.LogInfo("Game has bootstrapped. Worlds and systems now exist.");
 
         GameFrame.Initialize();
-        DBHelper.setAnnounceOnline(Plugin.AnnounceOnline.Value);
-        DBHelper.setAnnounceOffline(Plugin.AnnounceeOffline.Value);
-        DBHelper.setAnnounceNewUser(Plugin.AnnounceNewUser.Value);
-        DBHelper.setAnnounceVBlood(Plugin.AnnounceVBlood.Value);
-        DBHelper.setVBloodFinalConcatCharacters(Plugin.VBloodFinalConcatCharacters.Value);
-        DBHelper.setAutoAnnouncer(Plugin.AutoAnnouncerConfig.Value);
-        DBHelper.setMessageOfTheDayEnabled(Plugin.MessageOfTheDay.Value);
+
+		DBHelper.EnabledFeatures[NotifyFeature.online] = Plugin.AnnounceOnline.Value;
+		DBHelper.EnabledFeatures[NotifyFeature.offline] = Plugin.AnnounceeOffline.Value;
+		DBHelper.EnabledFeatures[NotifyFeature.newuser] = Plugin.AnnounceNewUser.Value;
+		DBHelper.EnabledFeatures[NotifyFeature.vblood] = Plugin.AnnounceVBlood.Value;
+		DBHelper.EnabledFeatures[NotifyFeature.auto] = Plugin.AutoAnnouncerConfig.Value;
+		DBHelper.EnabledFeatures[NotifyFeature.motd] = Plugin.MessageOfTheDay.Value;
+		
+
+		DBHelper.setVBloodFinalConcatCharacters(Plugin.VBloodFinalConcatCharacters.Value);
+
         DBHelper.setIntervalAutoAnnouncer(Plugin.IntervalAutoAnnouncer.Value);
         Plugin.Logger.LogInfo("GameData Init");
         _autoAnnouncerTimer = new AutoAnnouncerTimer();

--- a/Patch/OnInitialize.cs
+++ b/Patch/OnInitialize.cs
@@ -20,15 +20,15 @@ public class OnInitialize
 
         GameFrame.Initialize();
 
-		DBHelper.EnabledFeatures[NotifyFeature.online] = Plugin.AnnounceOnline.Value;
-		DBHelper.EnabledFeatures[NotifyFeature.offline] = Plugin.AnnounceeOffline.Value;
-		DBHelper.EnabledFeatures[NotifyFeature.newuser] = Plugin.AnnounceNewUser.Value;
-		DBHelper.EnabledFeatures[NotifyFeature.vblood] = Plugin.AnnounceVBlood.Value;
-		DBHelper.EnabledFeatures[NotifyFeature.auto] = Plugin.AutoAnnouncerConfig.Value;
-		DBHelper.EnabledFeatures[NotifyFeature.motd] = Plugin.MessageOfTheDay.Value;
-		
+        DBHelper.EnabledFeatures[NotifyFeature.online] = Plugin.AnnounceOnline.Value;
+        DBHelper.EnabledFeatures[NotifyFeature.offline] = Plugin.AnnounceeOffline.Value;
+        DBHelper.EnabledFeatures[NotifyFeature.newuser] = Plugin.AnnounceNewUser.Value;
+        DBHelper.EnabledFeatures[NotifyFeature.vblood] = Plugin.AnnounceVBlood.Value;
+        DBHelper.EnabledFeatures[NotifyFeature.auto] = Plugin.AutoAnnouncerConfig.Value;
+        DBHelper.EnabledFeatures[NotifyFeature.motd] = Plugin.MessageOfTheDay.Value;
 
-		DBHelper.setVBloodFinalConcatCharacters(Plugin.VBloodFinalConcatCharacters.Value);
+
+        DBHelper.setVBloodFinalConcatCharacters(Plugin.VBloodFinalConcatCharacters.Value);
 
         DBHelper.setIntervalAutoAnnouncer(Plugin.IntervalAutoAnnouncer.Value);
         Plugin.Logger.LogInfo("GameData Init");


### PR DESCRIPTION
## Overview
I noticed this config command and the would be a good fit to refactor to rely more on VCF. 

One significant thing to note is that the command currently requires a `bool` parsing value, so `true/false` . This is ideally handled in VCF.Core or a custom converter, that would also be able to handle localization nicely. I'd prefer you contribute something to VCF for this, but if you can't wait for that to merge you could make a custom converter and change the type to be a throwaway type like:
```cs
public record struct BoolLike(bool value);
public class BoolLikeConverter: CommandArgumentConverter<BoolLike>
{
    public override BoolLikeParse(ICommandContext ctx, string input)
    {
        // ex. I'd string, try normal bool converter first
        if(input == "enabled") return BoolLike(true);
        ...
    }
}
// then .., BoolLike isEnabled) as the command parameter 
```

## Testing
(done before white space changes)
![image](https://github.com/oscarpedrero/Notify/assets/62450933/7763abe1-6f86-461d-b72d-5c68e65f7e52)
